### PR TITLE
fix(ci): fix deploy page using book/html folder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate sitemap
         run: |
-          cd book
+          cd book/html
           npx static-sitemap-cli --base ${{ env.url }}
           cat sitemap.xml
 
@@ -65,7 +65,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages
-          folder: book
+          folder: book/html
 
       - name: Comment Commit
         if: github.event_name == 'push' && steps.deploy.outputs.deployment-status == 'success'


### PR DESCRIPTION
Note from https://github.com/Michael-F-Bryan/mdbook-linkcheck#mdbook-link-check

> Note: When multiple `[output]` items are specified, mdbook tries to ensure that each `[output]` gets its own sub-directory within the build-dir (`book/` by default).
>
> That means if you go from only having the HTML renderer enabled to enabling both HTML and the linkchecker, your HTML will be placed in `book/html/` instead of just `book/` like before.

